### PR TITLE
[Style/#36] 네비게이션 컴포넌트 구현

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/Navigation/CalendarNavigationBar.swift
+++ b/Projects/Shared/DesignSystem/Sources/Navigation/CalendarNavigationBar.swift
@@ -16,22 +16,32 @@ public struct CalendarNavigationBar: View {
         case month = "월"
     }
     
+    public let dateText: String
     public let onDateTapped: (() -> Void)?
     public let onToggleChanged: ((ToggleOption) -> Void)?
     
     public init(
+        dateText: String? = nil,
         onDateTapped: (() -> Void)? = nil,
         onToggleChanged: ((ToggleOption) -> Void)? = nil
     ) {
+        self.dateText = dateText ?? Self.currentDateText
         self.onDateTapped = onDateTapped
         self.onToggleChanged = onToggleChanged
+    }
+    
+    private static var currentDateText: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월"
+        return formatter.string(from: Date())
     }
     
     public var body: some View {
         HStack {
             Button(action: { onDateTapped?() }) {
                 HStack(spacing: 4) {
-                    Text("2025년 5월")
+                    Text(dateText)
                         .font(.heading4)
                         .foregroundColor(.black)
                     Image(.icnCaretDown)

--- a/Projects/Shared/DesignSystem/Sources/Navigation/CalendarNavigationBar.swift
+++ b/Projects/Shared/DesignSystem/Sources/Navigation/CalendarNavigationBar.swift
@@ -16,8 +16,8 @@ public struct CalendarNavigationBar: View {
         case month = "월"
     }
     
-    let onDateTapped: (() -> Void)?
-    let onToggleChanged: ((ToggleOption) -> Void)?
+    public let onDateTapped: (() -> Void)?
+    public let onToggleChanged: ((ToggleOption) -> Void)?
     
     public init(
         onDateTapped: (() -> Void)? = nil,
@@ -67,9 +67,16 @@ public struct CalendarNavigationBar: View {
                 }
             }
         }
-        .padding(.horizontal, 16)
-        .frame(height: 56)
-        .background(Color(.systemBackground))
+        .calendarNavigationBarStyle()
+    }
+}
+
+private extension View {
+    func calendarNavigationBarStyle() -> some View {
+        self
+            .padding(.horizontal, 16)
+            .frame(height: 56)
+            .background(Color(.systemBackground))
     }
 }
 

--- a/Projects/Shared/DesignSystem/Sources/Navigation/CalendarNavigationBar.swift
+++ b/Projects/Shared/DesignSystem/Sources/Navigation/CalendarNavigationBar.swift
@@ -1,0 +1,87 @@
+//
+//  CalendarNavigationBar.swift
+//  Shared
+//
+//  Created by 이지훈 on 6/18/25.
+//  Copyright © 2025 com.noweekend. All rights reserved.
+//
+
+import SwiftUI
+
+public struct CalendarNavigationBar: View {
+    @State private var selectedToggle: ToggleOption = .week
+    
+    public enum ToggleOption: String, CaseIterable {
+        case week = "주"
+        case month = "월"
+    }
+    
+    let onDateTapped: (() -> Void)?
+    let onToggleChanged: ((ToggleOption) -> Void)?
+    
+    public init(
+        onDateTapped: (() -> Void)? = nil,
+        onToggleChanged: ((ToggleOption) -> Void)? = nil
+    ) {
+        self.onDateTapped = onDateTapped
+        self.onToggleChanged = onToggleChanged
+    }
+    
+    public var body: some View {
+        HStack {
+            Button(action: { onDateTapped?() }) {
+                HStack(spacing: 4) {
+                    Text("2025년 5월")
+                        .font(.heading4)
+                        .foregroundColor(.black)
+                    Image(.icnCaretDown)
+                }
+            }
+            
+            Spacer()
+            
+            ZStack {
+                Capsule()
+                    .fill(DS.Colors.Neutral._200)
+                    .frame(width: 72, height: 38)
+                
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 32, height: 32)
+                    .shadow(color: .black.opacity(0.1), radius: 16, x: 0, y: 0)
+                    .offset(x: selectedToggle == .week ? -16 : 16)
+                    .animation(.interpolatingSpring(stiffness: 200, damping: 20), value: selectedToggle)
+                
+                HStack(spacing: 0) {
+                    ForEach(ToggleOption.allCases, id: \.self) { option in
+                        Button(action: {
+                            selectedToggle = option
+                            onToggleChanged?(option)
+                        }) {
+                            Text(option.rawValue)
+                                .font(.heading6)
+                                .foregroundColor(selectedToggle == option ? DS.Colors.Neutral._900 : DS.Colors.Neutral._700)
+                                .frame(width: 32, height: 32)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 56)
+        .background(Color(.systemBackground))
+    }
+}
+
+// MARK: - Preview
+#Preview {
+    CalendarNavigationBar(
+        onDateTapped: {
+            print("날짜 버튼 클릭")
+        },
+        onToggleChanged: { toggle in
+            print("토글 변경: \(toggle.rawValue)")
+        }
+    )
+    .background(Color.white)
+}

--- a/Projects/Shared/DesignSystem/Sources/Navigation/CustomNavigationBar.swift
+++ b/Projects/Shared/DesignSystem/Sources/Navigation/CustomNavigationBar.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 
-// MARK: - Custom Navigation Component
 public struct CustomNavigationBar: View {
     public enum NavigationType {
         case backOnly
@@ -17,10 +16,10 @@ public struct CustomNavigationBar: View {
         case cancelWithLabelAndSave(String)
     }
     
-    let type: NavigationType
-    let onBackTapped: (() -> Void)?
-    let onCancelTapped: (() -> Void)?
-    let onSaveTapped: (() -> Void)?
+    public let type: NavigationType
+    public let onBackTapped: (() -> Void)?
+    public let onCancelTapped: (() -> Void)?
+    public let onSaveTapped: (() -> Void)?
     
     public init(
         type: NavigationType,
@@ -36,38 +35,31 @@ public struct CustomNavigationBar: View {
     
     public var body: some View {
         ZStack {
-            HStack {
-                leftButton
-                
-                Spacer()
-                
-                rightButton
-            }
-            
+            navigationContent
             centerLabel
         }
-        .padding(.horizontal, 16)
-        .frame(height: 56)
-        .background(Color(.systemBackground))
+        .customNavigationBarStyle()
     }
 }
 
-// MARK: - Private Views
 private extension CustomNavigationBar {
+    var navigationContent: some View {
+        HStack {
+            leftButtonContent
+            Spacer()
+            rightButtonContent
+        }
+    }
+    
     @ViewBuilder
-    var leftButton: some View {
+    var leftButtonContent: some View {
         switch type {
         case .backOnly, .backWithLabel, .backWithLabelAndSave:
-            Button(action: {
-                onBackTapped?()
-            }) {
+            Button(action: { onBackTapped?() }) {
                 Image(.icnChevronLeft)
             }
-            
         case .cancelWithLabelAndSave:
-            Button(action: {
-                onCancelTapped?()
-            }) {
+            Button(action: { onCancelTapped?() }) {
                 Text("취소")
                     .font(.heading6)
                     .foregroundColor(DS.Colors.Text.gray700)
@@ -80,79 +72,85 @@ private extension CustomNavigationBar {
         switch type {
         case .backOnly:
             EmptyView()
-            
         case .backWithLabel(let title),
              .backWithLabelAndSave(let title),
              .cancelWithLabelAndSave(let title):
             Text(title)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.primary)
+                .navigationTitleStyle()
         }
     }
     
     @ViewBuilder
-    var rightButton: some View {
+    var rightButtonContent: some View {
         switch type {
         case .backOnly, .backWithLabel:
             Color.clear
                 .frame(width: 60, height: 32)
-            
         case .backWithLabelAndSave, .cancelWithLabelAndSave:
-            Button(action: {
-                onSaveTapped?()
-            }) {
+            Button(action: { onSaveTapped?() }) {
                 Text("저장")
                     .font(.heading6)
-                        .foregroundColor(DS.Colors.Toast._500)
+                    .foregroundColor(DS.Colors.Toast._500)
             }
         }
+    }
+}
+
+private extension View {
+    func customNavigationBarStyle() -> some View {
+        self
+            .padding(.horizontal, 16)
+            .frame(height: 56)
+            .background(Color(.systemBackground))
+    }
+    
+    func navigationTitleStyle() -> some View {
+        self
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundColor(.primary)
+    }
+    
+    func previewContainerStyle() -> some View {
+        self.background(Color.gray.opacity(0.1))
+    }
+    
+    func previewNavigationBarBackground() -> some View {
+        self.background(Color.white)
     }
 }
 
 // MARK: - Preview
 #Preview {
     VStack(spacing: 1) {
-        // 1. 뒤로가기만 있는 버전
+        // Back Only
         CustomNavigationBar(
             type: .backOnly,
-            onBackTapped: {
-                print("뒤로가기 tapped")
-            }
+            onBackTapped: { print("뒤로가기 tapped") }
         )
-        .background(Color.white)
+        .previewNavigationBarBackground()
         
-        // 2. 뒤로가기 + 가운데 레이블
+        // Back with Label
         CustomNavigationBar(
             type: .backWithLabel("세부사항"),
-            onBackTapped: {
-                print("뒤로가기 tapped")
-            }
+            onBackTapped: { print("뒤로가기 tapped") }
         )
-        .background(Color.white)
+        .previewNavigationBarBackground()
         
-        // 3. 뒤로가기 + 가운데 레이블 + 저장하기 버튼
+        // Back with Label and Save
         CustomNavigationBar(
             type: .backWithLabelAndSave("프로필 편집"),
-            onBackTapped: {
-                print("뒤로가기 tapped")
-            },
-            onSaveTapped: {
-                print("저장하기 tapped")
-            }
+            onBackTapped: { print("뒤로가기 tapped") },
+            onSaveTapped: { print("저장하기 tapped") }
         )
-        .background(Color.white)
+        .previewNavigationBarBackground()
         
-        // 4. 취소 + 가운데 레이블 + 저장하기 버튼
+        // Cancel with Label and Save
         CustomNavigationBar(
             type: .cancelWithLabelAndSave("새 게시물"),
-            onCancelTapped: {
-                print("취소 tapped")
-            },
-            onSaveTapped: {
-                print("저장하기 tapped")
-            }
+            onCancelTapped: { print("취소 tapped") },
+            onSaveTapped: { print("저장하기 tapped") }
         )
-        .background(Color.white)
+        .previewNavigationBarBackground()
     }
-    .background(Color.gray.opacity(0.1))
+    .previewContainerStyle()
 }

--- a/Projects/Shared/DesignSystem/Sources/Navigation/CustomNavigationBar.swift
+++ b/Projects/Shared/DesignSystem/Sources/Navigation/CustomNavigationBar.swift
@@ -1,0 +1,158 @@
+//
+//  CustomNavigationBar.swift
+//  Shared
+//
+//  Created by 이지훈 on 6/18/25.
+//  Copyright © 2025 com.noweekend. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: - Custom Navigation Component
+public struct CustomNavigationBar: View {
+    public enum NavigationType {
+        case backOnly
+        case backWithLabel(String)
+        case backWithLabelAndSave(String)
+        case cancelWithLabelAndSave(String)
+    }
+    
+    let type: NavigationType
+    let onBackTapped: (() -> Void)?
+    let onCancelTapped: (() -> Void)?
+    let onSaveTapped: (() -> Void)?
+    
+    public init(
+        type: NavigationType,
+        onBackTapped: (() -> Void)? = nil,
+        onCancelTapped: (() -> Void)? = nil,
+        onSaveTapped: (() -> Void)? = nil
+    ) {
+        self.type = type
+        self.onBackTapped = onBackTapped
+        self.onCancelTapped = onCancelTapped
+        self.onSaveTapped = onSaveTapped
+    }
+    
+    public var body: some View {
+        ZStack {
+            HStack {
+                leftButton
+                
+                Spacer()
+                
+                rightButton
+            }
+            
+            centerLabel
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 56)
+        .background(Color(.systemBackground))
+    }
+}
+
+// MARK: - Private Views
+private extension CustomNavigationBar {
+    @ViewBuilder
+    var leftButton: some View {
+        switch type {
+        case .backOnly, .backWithLabel, .backWithLabelAndSave:
+            Button(action: {
+                onBackTapped?()
+            }) {
+                Image(.icnChevronLeft)
+            }
+            
+        case .cancelWithLabelAndSave:
+            Button(action: {
+                onCancelTapped?()
+            }) {
+                Text("취소")
+                    .font(.heading6)
+                    .foregroundColor(DS.Colors.Text.gray700)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var centerLabel: some View {
+        switch type {
+        case .backOnly:
+            EmptyView()
+            
+        case .backWithLabel(let title),
+             .backWithLabelAndSave(let title),
+             .cancelWithLabelAndSave(let title):
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.primary)
+        }
+    }
+    
+    @ViewBuilder
+    var rightButton: some View {
+        switch type {
+        case .backOnly, .backWithLabel:
+            Color.clear
+                .frame(width: 60, height: 32)
+            
+        case .backWithLabelAndSave, .cancelWithLabelAndSave:
+            Button(action: {
+                onSaveTapped?()
+            }) {
+                Text("저장")
+                    .font(.heading6)
+                        .foregroundColor(DS.Colors.Toast._500)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+#Preview {
+    VStack(spacing: 1) {
+        // 1. 뒤로가기만 있는 버전
+        CustomNavigationBar(
+            type: .backOnly,
+            onBackTapped: {
+                print("뒤로가기 tapped")
+            }
+        )
+        .background(Color.white)
+        
+        // 2. 뒤로가기 + 가운데 레이블
+        CustomNavigationBar(
+            type: .backWithLabel("세부사항"),
+            onBackTapped: {
+                print("뒤로가기 tapped")
+            }
+        )
+        .background(Color.white)
+        
+        // 3. 뒤로가기 + 가운데 레이블 + 저장하기 버튼
+        CustomNavigationBar(
+            type: .backWithLabelAndSave("프로필 편집"),
+            onBackTapped: {
+                print("뒤로가기 tapped")
+            },
+            onSaveTapped: {
+                print("저장하기 tapped")
+            }
+        )
+        .background(Color.white)
+        
+        // 4. 취소 + 가운데 레이블 + 저장하기 버튼
+        CustomNavigationBar(
+            type: .cancelWithLabelAndSave("새 게시물"),
+            onCancelTapped: {
+                print("취소 tapped")
+            },
+            onSaveTapped: {
+                print("저장하기 tapped")
+            }
+        )
+        .background(Color.white)
+    }
+    .background(Color.gray.opacity(0.1))
+}

--- a/Projects/Shared/DesignSystem/Sources/Navigation/NavigationExampleView.swift
+++ b/Projects/Shared/DesignSystem/Sources/Navigation/NavigationExampleView.swift
@@ -1,0 +1,81 @@
+//
+//  NavigationExampleView.swift
+//  Shared
+//
+//  Created by 이지훈 on 6/19/25.
+//  Copyright © 2025 com.noweekend. All rights reserved.
+//
+
+import SwiftUI
+
+// MARK: - All Navigation Bars Preview
+public struct NavigationExampleView: View {
+    @State private var selectedToggle: CalendarNavigationBar.ToggleOption = .week
+    
+    public init() {}
+    
+    public var body: some View {
+        VStack(spacing: 1) {
+            // 1. 캘린더 네비게이션 바
+            CalendarNavigationBar(
+                onDateTapped: {
+                    print("날짜 버튼 클릭")
+                },
+                onToggleChanged: { toggle in
+                    print("토글 변경: \(toggle.rawValue)")
+                }
+            )
+            .background(Color.white)
+            
+            // 2. 뒤로가기만
+            CustomNavigationBar(
+                type: .backOnly,
+                onBackTapped: {
+                    print("뒤로가기 tapped")
+                }
+            )
+            .background(Color.white)
+            
+            // 3. 뒤로가기 + 레이블
+            CustomNavigationBar(
+                type: .backWithLabel("세부사항"),
+                onBackTapped: {
+                    print("뒤로가기 tapped")
+                }
+            )
+            .background(Color.white)
+            
+            // 4. 뒤로가기 + 레이블 + 저장
+            CustomNavigationBar(
+                type: .backWithLabelAndSave("프로필 편집"),
+                onBackTapped: {
+                    print("뒤로가기 tapped")
+                },
+                onSaveTapped: {
+                    print("저장하기 tapped")
+                }
+            )
+            .background(Color.white)
+            
+            // 5. 취소 + 레이블 + 저장
+            CustomNavigationBar(
+                type: .cancelWithLabelAndSave("새 게시물"),
+                onCancelTapped: {
+                    print("취소 tapped")
+                },
+                onSaveTapped: {
+                    print("저장하기 tapped")
+                }
+            )
+            .background(Color.white)
+            
+            Spacer()
+        }
+        .background(Color(.systemGray6))
+    }
+}
+
+// MARK: - Preview
+#Preview {
+    NavigationExampleView()
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #36 


## 📄 작업 내용
- 네비게이션 컴포넌트를 구현했습니다

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/b45ebd83-71f1-4abb-a72f-7414d321bad8" width ="250"> | <img src = "" width ="250"> |

## 💻 주요 코드 설명

모든(5가지 경우) 네비게이션 컴포넌트를 구현했습니다.
만약 제가 놓친경우가 있다면 다시 추가해둘게요!

```swift
            CalendarNavigationBar(
                onDateTapped: {
                    print("날짜 버튼 클릭")
                },
                onToggleChanged: { toggle in
                    print("토글 변경: \(toggle.rawValue)")
                }
            )
```
이런식으로 CalendarNavigationBar 을 선언해서 사용하시면 되는데 어려우면 NavigationExampleView 코드를 보시면 바로 사용하실수 있을듯합니다!


### ✔️ CI Completed
- ✅ Lint: Completed
- ✅ Build: Completed



### ✔️ CI Completed
- ✅ Lint: Completed
- ✅ Build: Completed
