### PR TITLE
feat/#30-TextField KeyboardDismiss 추가

### DIFF
--- a/Projects/Shared/DesignSystem/Sources/UIComponents/NWTextField/KeyboardDismissalModifier.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIComponents/NWTextField/KeyboardDismissalModifier.swift
@@ -1,0 +1,31 @@
+//
+//  KeyboardDismissalModifier.swift
+//  DesignSystem
+//
+//  Created by SiJongKim on 7/2/25.
+//  Copyright © 2025 com.noweekend. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+public extension UIApplication {
+    func dismissKeyboard() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+
+public struct KeyboardDismissalModifier: ViewModifier {
+    public func body(content: Content) -> some View {
+        content
+            .onTapGesture {
+                UIApplication.shared.dismissKeyboard()
+            }
+    }
+}
+
+public extension View {
+    func dismissKeyboardOnTap() -> some View {
+        modifier(KeyboardDismissalModifier())
+    }
+}

--- a/Projects/Shared/DesignSystem/Sources/UIComponents/NWTextField/NWTextViewCoordinator.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIComponents/NWTextField/NWTextViewCoordinator.swift
@@ -59,6 +59,11 @@ public final class NWTextViewCoordinator: NSObject, UITextViewDelegate {
     }
     
     public func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" {
+            textView.resignFirstResponder()
+            return false
+        }
+        
         if textView.text == placeholder && !text.isEmpty {
             textView.text = ""
             textView.textColor = UIColor(DS.Colors.Text.netural)


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #30


## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 텍스트필드 키보드 Dismiss 구현


## 💻 주요 코드 설명

### 개요
화면 아무 곳이나 탭하면 키보드가 자동으로 해제되는 기능을 추가했습니다.

### 변경사항
- `KeyboardDismissalModifier.swift` 파일 추가
- `.dismissKeyboardOnTap()` View extension 제공

### 사용예시
```swift
VStack {
   NWTextField.todoMultiLine(...)
}
.dismissKeyboardOnTap()
```

```swift
public struct OnboardingView: View {
    @ObservedObject private var store: OnboardingStore
    
    public var body: some View {
        VStack(spacing: 0) {
            headerView
            
            TabView(selection: $store.state.currentStep) {
                nicknameStepView.tag(0)
                experienceStepView.tag(1)
                scheduleStepView.tag(2)
            }
            
            bottomButtonView
        }
        .background(DS.Colors.Background.white)
        .dismissKeyboardOnTap() // 👈 전체 온보딩 화면에 적용
    }
}
```



### ✔️ CI Completed
- ✅ Lint: Completed
- ✅ Build: Completed
