### PR TITLE
[feat/#78] 뒤로 미루기 로직 및 할일 컴포넌트 수정

### DIFF
--- a/Projects/App/Sources/ContentView.swift
+++ b/Projects/App/Sources/ContentView.swift
@@ -31,9 +31,9 @@ struct ContentView: View {
         if appState.isLoading {
             LoadingView()
         } else if !appState.isLoggedIn {
-            OnboardingView()
+            TabBarView()
         } else if !appState.isOnboardingCompleted {
-            OnboardingView()
+            TabBarView()
         } else {
             TabBarView()
         }

--- a/Projects/App/Sources/ContentView.swift
+++ b/Projects/App/Sources/ContentView.swift
@@ -31,9 +31,9 @@ struct ContentView: View {
         if appState.isLoading {
             LoadingView()
         } else if !appState.isLoggedIn {
-            TabBarView()
+            OnboardingView()
         } else if !appState.isOnboardingCompleted {
-            TabBarView()
+            OnboardingView()
         } else {
             TabBarView()
         }

--- a/Projects/Calendar/CalendarFeature/Sources/Coordinator/CalendarCoordinator.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Coordinator/CalendarCoordinator.swift
@@ -61,33 +61,6 @@ public enum CalendarRouter {
         case main
         case taskCreate(selectedDate: Date)
         case taskEdit(todoId: Int, title: String, category: String?, scheduleId: String?, selectedDate: Date)
-        
-        public func hash(into hasher: inout Hasher) {
-            switch self {
-            case .main:
-                hasher.combine("main")
-            case .taskCreate(let selectedDate):
-                hasher.combine("taskCreate")
-                hasher.combine(selectedDate.timeIntervalSince1970)
-            case .taskEdit(let todoId, _, _, _, let selectedDate):
-                hasher.combine("taskEdit")
-                hasher.combine(todoId)
-                hasher.combine(selectedDate.timeIntervalSince1970)
-            }
-        }
-        
-        public static func == (lhs: CalendarRouter.Screen, rhs: CalendarRouter.Screen) -> Bool {
-            switch (lhs, rhs) {
-            case (.main, .main):
-                return true
-            case (.taskCreate(let lhsDate), .taskCreate(let rhsDate)):
-                return lhsDate == rhsDate
-            case (.taskEdit(let lhsId, _, _, _, let lhsDate), .taskEdit(let rhsId, _, _, _, let rhsDate)):
-                return lhsId == rhsId && lhsDate == rhsDate
-            default:
-                return false
-            }
-        }
     }
     
     public enum Sheet: String, Identifiable {

--- a/Projects/Calendar/CalendarFeature/Sources/Views/Todo/TodoScrollSection.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/Todo/TodoScrollSection.swift
@@ -103,13 +103,7 @@ struct TodoScrollSection: View {
                         onMoreTapped: {
                             selectedTaskIndex = index
                             showTaskEditSheet = true
-                        },
-                        onTitleChanged: { newTitle in
-                            todoItems[index].title = newTitle
-                            editingTaskIndex = nil
-                            onTitleChanged?(index, newTitle)
-                        },
-                        isEditingMode: editingTaskIndex == index
+                        }
                     )
                     .contentShape(Rectangle())
                 }

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarModels.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarModels.swift
@@ -20,6 +20,7 @@ public enum CalendarIntent {
     case categorySelected(TaskCategory)
     case directInputTapped
     case taskEditRequested(Int)
+    case taskTomorrowRequested(Int)
     case taskDeleteRequested(Int)
     case taskTitleChanged(Int, String)
     case categorySelectionToggled
@@ -63,11 +64,12 @@ public struct CalendarState: Equatable {
     }
 }
 
-// MARK: - Effect 
+// MARK: - Effect
 public enum CalendarEffect {
     case navigateToTaskCreate(Date)
     case navigateToTaskEdit(Int, String, String?, String?, Date)
     case showError(String)
+    case showSuccess(String)
 }
 
 // MARK: - Domain Extensions

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
@@ -32,11 +32,9 @@ public struct CalendarView: View {
         .sheet(isPresented: $showDatePickerSheet) {
             DatePickerWithLabelBottomSheet(selectedDate: $datePickerSelectedDate)
                 .onAppear {
-                    print("🔵 DatePicker sheet appeared")
                     datePickerSelectedDate = store.state.selectedDate
                 }
                 .onDisappear {
-                    print("🔵 DatePicker sheet disappeared")
                     if datePickerSelectedDate != store.state.selectedDate {
                         store.send(.dateSelected(datePickerSelectedDate))
                     }
@@ -45,21 +43,18 @@ public struct CalendarView: View {
         .sheet(isPresented: $showTaskEditSheet) {
             TaskEditBottomSheet(
                 onEditAction: {
-                    print("🟡 Edit action triggered")
                     if let index = store.state.selectedTaskIndex {
                         store.send(.taskEditRequested(index))
                     }
                     showTaskEditSheet = false
                 },
                 onTomorrowAction: {
-                    print("🟡 Tomorrow action triggered")
                     if let index = store.state.selectedTaskIndex {
                         store.send(.taskTomorrowRequested(index))
                     }
                     showTaskEditSheet = false
                 },
                 onDeleteAction: {
-                    print("🟡 Delete action triggered")
                     if let index = store.state.selectedTaskIndex {
                         store.send(.taskDeleteRequested(index))
                     }
@@ -69,11 +64,8 @@ public struct CalendarView: View {
                 isPresented: $showTaskEditSheet
             )
             .onAppear {
-                print("🟡 TaskEdit sheet appeared")
             }
             .onDisappear {
-                print("🟡 TaskEdit sheet disappeared")
-                // 🔥 Store 상태도 동기화
                 Task { @MainActor in
                     store.updateState { state in
                         state.showTaskEditSheet = false
@@ -83,7 +75,6 @@ public struct CalendarView: View {
             }
         }
         .onChange(of: store.state.showTaskEditSheet) { _, newValue in
-            print("🟢 Store showTaskEditSheet changed to: \(newValue)")
             if newValue != showTaskEditSheet {
                 showTaskEditSheet = newValue
             }
@@ -104,7 +95,6 @@ private extension CalendarView {
             CalendarNavigationBar(
                 dateText: store.state.currentDateString,
                 onDateTapped: {
-                    print("🔵 Navigation bar date tapped - showing DatePicker sheet")
                     showDatePickerSheet = true
                 },
                 onToggleChanged: { toggle in
@@ -116,7 +106,6 @@ private extension CalendarView {
                 selectedDate: store.state.selectedDate,
                 selectedToggle: store.state.selectedToggle,
                 onDateTap: { date in
-                    print("🟢 Calendar cell tapped: \(date) - direct date selection")
                     store.send(.dateSelected(date))
                 },
                 calendarCellContent: store.calendarCellContent
@@ -154,7 +143,6 @@ private extension CalendarView {
                                 store.updateState { state in
                                     state.selectedTaskIndex = newValue
                                     if newValue != nil {
-                                        print("🟡 Task selected at index: \(newValue!) - showing TaskEdit sheet")
                                         state.showTaskEditSheet = true
                                     }
                                 }
@@ -164,7 +152,6 @@ private extension CalendarView {
                     showTaskEditSheet: Binding(
                         get: { showTaskEditSheet },
                         set: { newValue in
-                            print("🟡 TodoScrollSection trying to set showTaskEditSheet to: \(newValue)")
                             showTaskEditSheet = newValue
                         }
                     ),

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
@@ -16,7 +16,10 @@ import Utils
 public struct CalendarView: View {
     @EnvironmentObject private var coordinator: CalendarCoordinator
     @StateObject private var store = CalendarStore()
-    @State private var previousSelectedDate: Date?
+    
+    @State private var showDatePickerSheet = false
+    @State private var showTaskEditSheet = false
+    @State private var datePickerSelectedDate = Date()
     
     public init() {}
     
@@ -26,47 +29,64 @@ public struct CalendarView: View {
             overlayContent
             floatingButton
         }
-        .sheet(isPresented: Binding(
-            get: { store.state.showDatePicker },
-            set: { store.send(.dateSelected($0 ? store.state.selectedDate : store.state.selectedDate)) }
-        )) {
-            DatePickerWithLabelBottomSheet(selectedDate: Binding(
-                get: { store.state.selectedDate },
-                set: { store.send(.dateSelected($0)) }
-            ))
-            .onAppear {
-                previousSelectedDate = store.state.selectedDate
-            }
+        .sheet(isPresented: $showDatePickerSheet) {
+            DatePickerWithLabelBottomSheet(selectedDate: $datePickerSelectedDate)
+                .onAppear {
+                    print("🔵 DatePicker sheet appeared")
+                    datePickerSelectedDate = store.state.selectedDate
+                }
+                .onDisappear {
+                    print("🔵 DatePicker sheet disappeared")
+                    if datePickerSelectedDate != store.state.selectedDate {
+                        store.send(.dateSelected(datePickerSelectedDate))
+                    }
+                }
         }
-        .sheet(isPresented: Binding(
-            get: { store.state.showTaskEditSheet },
-            set: { _ in }
-        )) {
+        .sheet(isPresented: $showTaskEditSheet) {
             TaskEditBottomSheet(
                 onEditAction: {
+                    print("🟡 Edit action triggered")
                     if let index = store.state.selectedTaskIndex {
                         store.send(.taskEditRequested(index))
                     }
+                    showTaskEditSheet = false
                 },
                 onTomorrowAction: {
-                    Task { @MainActor in
-                        store.updateState { $0.showTaskEditSheet = false }
+                    print("🟡 Tomorrow action triggered")
+                    if let index = store.state.selectedTaskIndex {
+                        store.send(.taskTomorrowRequested(index))
                     }
+                    showTaskEditSheet = false
                 },
                 onDeleteAction: {
+                    print("🟡 Delete action triggered")
                     if let index = store.state.selectedTaskIndex {
                         store.send(.taskDeleteRequested(index))
                     }
+                    showTaskEditSheet = false
                 },
-                isPresented: Binding(
-                    get: { store.state.showTaskEditSheet },
-                    set: { newValue in
-                        Task { @MainActor in
-                            store.updateState { $0.showTaskEditSheet = newValue }
-                        }
-                    }
-                )
+                isVacationTask: isSelectedTaskVacation(),
+                isPresented: $showTaskEditSheet
             )
+            .onAppear {
+                print("🟡 TaskEdit sheet appeared")
+            }
+            .onDisappear {
+                print("🟡 TaskEdit sheet disappeared")
+                // 🔥 Store 상태도 동기화
+                Task { @MainActor in
+                    store.updateState { state in
+                        state.showTaskEditSheet = false
+                        state.selectedTaskIndex = nil
+                    }
+                }
+            }
+        }
+        .onChange(of: store.state.showTaskEditSheet) { _, newValue in
+            print("🟢 Store showTaskEditSheet changed to: \(newValue)")
+            if newValue != showTaskEditSheet {
+                showTaskEditSheet = newValue
+            }
         }
         .onReceive(store.effect) { effect in
             handleEffect(effect)
@@ -84,9 +104,8 @@ private extension CalendarView {
             CalendarNavigationBar(
                 dateText: store.state.currentDateString,
                 onDateTapped: {
-                    Task { @MainActor in
-                        store.updateState { $0.showDatePicker = true }
-                    }
+                    print("🔵 Navigation bar date tapped - showing DatePicker sheet")
+                    showDatePickerSheet = true
                 },
                 onToggleChanged: { toggle in
                     store.send(.toggleChanged(toggle))
@@ -97,6 +116,7 @@ private extension CalendarView {
                 selectedDate: store.state.selectedDate,
                 selectedToggle: store.state.selectedToggle,
                 onDateTap: { date in
+                    print("🟢 Calendar cell tapped: \(date) - direct date selection")
                     store.send(.dateSelected(date))
                 },
                 calendarCellContent: store.calendarCellContent
@@ -131,16 +151,21 @@ private extension CalendarView {
                         get: { store.state.selectedTaskIndex },
                         set: { newValue in
                             Task { @MainActor in
-                                store.updateState { $0.selectedTaskIndex = newValue }
+                                store.updateState { state in
+                                    state.selectedTaskIndex = newValue
+                                    if newValue != nil {
+                                        print("🟡 Task selected at index: \(newValue!) - showing TaskEdit sheet")
+                                        state.showTaskEditSheet = true
+                                    }
+                                }
                             }
                         }
                     ),
                     showTaskEditSheet: Binding(
-                        get: { store.state.showTaskEditSheet },
+                        get: { showTaskEditSheet },
                         set: { newValue in
-                            Task { @MainActor in
-                                store.updateState { $0.showTaskEditSheet = newValue }
-                            }
+                            print("🟡 TodoScrollSection trying to set showTaskEditSheet to: \(newValue)")
+                            showTaskEditSheet = newValue
                         }
                     ),
                     scrollOffset: Binding(
@@ -217,6 +242,18 @@ private extension CalendarView {
     }
 }
 
+// MARK: - Helper Methods
+private extension CalendarView {
+    func isSelectedTaskVacation() -> Bool {
+        guard let selectedIndex = store.state.selectedTaskIndex,
+              selectedIndex < store.state.todoItems.count else {
+            return false
+        }
+        
+        return store.state.todoItems[selectedIndex].category?.name == "연차"
+    }
+}
+
 // MARK: - Effect Handling
 private extension CalendarView {
     func handleEffect(_ effect: CalendarEffect) {
@@ -233,8 +270,11 @@ private extension CalendarView {
                 selectedDate: selectedDate
             ))
             
-        case .showError:
-            break
+        case .showError(let message):
+            print("❌ Error: \(message)")
+            
+        case .showSuccess(let message):
+            print("✅ Success: \(message)")
         }
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/UIComponents/BottomSheet/TaskEdit/TaskEditBottomSheet.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIComponents/BottomSheet/TaskEdit/TaskEditBottomSheet.swift
@@ -1,5 +1,5 @@
 //
-//  TaskEditBottomSheet.swift
+//  TaskEditBottomSheet.swift - 연차 처리 추가
 //  Shared
 //
 //  Created by 이지훈 on 6/18/25.
@@ -12,45 +12,62 @@ public struct TaskEditBottomSheet: View {
     public let onEditAction: () -> Void
     public let onTomorrowAction: () -> Void
     public let onDeleteAction: () -> Void
+    public let isVacationTask: Bool
     @Binding public var isPresented: Bool
     
     public init(
         onEditAction: @escaping () -> Void,
         onTomorrowAction: @escaping () -> Void,
         onDeleteAction: @escaping () -> Void,
+        isVacationTask: Bool = false,
         isPresented: Binding<Bool>
     ) {
         self.onEditAction = onEditAction
         self.onTomorrowAction = onTomorrowAction
         self.onDeleteAction = onDeleteAction
+        self.isVacationTask = isVacationTask
         self._isPresented = isPresented
     }
     
     public var body: some View {
-        BottomSheetContainer(height: 192) {
+        BottomSheetContainer(height: isVacationTask ? 136 : 192) {
             ActionList(
-                items: [
-                    ActionItem(
-                        image: Image(.icnEdit),
-                        title: " 할 일 수정",
-                        textColor: DS.Colors.Text.netural,
-                        action: onEditAction
-                    ),
-                    ActionItem(
-                        image: Image(.icnArrowForward),
-                        title: "내일 또 하기",
-                        textColor: DS.Colors.Text.netural,
-                        action: onTomorrowAction
-                    ),
-                    ActionItem(
-                        image: Image(.icnDelete),
-                        title: "삭제하기",
-                        textColor: DS.Colors.Text.netural,
-                        action: onDeleteAction
-                    )
-                ],
+                items: actionItems,
                 isPresented: $isPresented
             )
         }
+    }
+    
+    private var actionItems: [ActionItem] {
+        var items = [
+            ActionItem(
+                image: Image(.icnEdit),
+                title: " 할 일 수정",
+                textColor: DS.Colors.Text.netural,
+                action: onEditAction
+            )
+        ]
+        
+        if !isVacationTask {
+            items.append(
+                ActionItem(
+                    image: Image(.icnArrowForward),
+                    title: "내일 또 하기",
+                    textColor: DS.Colors.Text.netural,
+                    action: onTomorrowAction
+                )
+            )
+        }
+        
+        items.append(
+            ActionItem(
+                image: Image(.icnDelete),
+                title: "삭제하기",
+                textColor: DS.Colors.Text.netural,
+                action: onDeleteAction
+            )
+        )
+        
+        return items
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/UIComponents/TodoList/TodoCheckboxComponent.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIComponents/TodoList/TodoCheckboxComponent.swift
@@ -1,5 +1,5 @@
 //
-//  TodoCheckboxComponent.swift - onMoreTapped 수정
+//  TodoCheckboxComponent.swift
 //  Shared
 //
 //  Created by 이지훈 on 6/22/25.
@@ -24,7 +24,7 @@ public struct TodoItem: Identifiable {
     public var isCompleted: Bool
     public let category: TodoCategory?
     public let time: String?
-    public let scheduleId: String?  // 🔥 추가: API에서 온 일정의 ID
+    public let scheduleId: String?
     
     public init(id: Int, title: String, isCompleted: Bool, category: TodoCategory?, time: String?, scheduleId: String? = nil) {
         self.id = id
@@ -40,25 +40,15 @@ public struct TodoCheckboxComponent: View {
     public let todoItem: TodoItem
     public let onToggle: () -> Void
     public let onMoreTapped: (() -> Void)?
-    public let onTitleChanged: ((String) -> Void)?
-    public let isEditingMode: Bool
-    
-    @State private var isEditing: Bool = false
-    @State private var editingTitle: String = ""
-    @FocusState private var isTextFieldFocused: Bool
     
     public init(
         todoItem: TodoItem,
         onToggle: @escaping () -> Void,
-        onMoreTapped: (() -> Void)? = nil,
-        onTitleChanged: ((String) -> Void)? = nil,
-        isEditingMode: Bool = false
+        onMoreTapped: (() -> Void)? = nil
     ) {
         self.todoItem = todoItem
         self.onToggle = onToggle
         self.onMoreTapped = onMoreTapped
-        self.onTitleChanged = onTitleChanged
-        self.isEditingMode = isEditingMode
     }
     
     public init(
@@ -67,9 +57,7 @@ public struct TodoCheckboxComponent: View {
         category: TodoCategory? = TodoCategory(name: "개인", color: DS.Colors.TaskItem.orange),
         time: String? = nil,
         onToggle: @escaping () -> Void,
-        onMoreTapped: (() -> Void)? = nil,
-        onTitleChanged: ((String) -> Void)? = nil,
-        isEditingMode: Bool = false
+        onMoreTapped: (() -> Void)? = nil
     ) {
         self.todoItem = TodoItem(
             id: 0,
@@ -81,8 +69,6 @@ public struct TodoCheckboxComponent: View {
         )
         self.onToggle = onToggle
         self.onMoreTapped = onMoreTapped
-        self.onTitleChanged = onTitleChanged
-        self.isEditingMode = isEditingMode
     }
     
     private var timeOrDate: String {
@@ -104,7 +90,10 @@ public struct TodoCheckboxComponent: View {
             }
             
             VStack(alignment: .leading, spacing: 4) {
-                titleSection
+                Text(todoItem.title)
+                    .font(.body2)
+                    .foregroundColor(DS.Colors.Neutral.gray900)
+                    .lineLimit(1)
                 
                 if todoItem.category != nil {
                     HStack(spacing: 8) {
@@ -129,73 +118,20 @@ public struct TodoCheckboxComponent: View {
             
             Spacer()
             
-            // 🔥 더보기 버튼 - 정확한 동작 보장
             Button(action: {
-                print("🟡 More button tapped for todo: \(todoItem.title)")
                 onMoreTapped?()
             }) {
                 DS.Images.icnThreeDots
                     .resizable()
                     .frame(width: 32, height: 32)
             }
-            .buttonStyle(PlainButtonStyle()) // 🔥 버튼 스타일 명시
+            .buttonStyle(PlainButtonStyle())
         }
         .padding(.vertical, 12)
         .padding(.leading, 24)
         .padding(.trailing, 16)
         .opacity(todoItem.isCompleted ? 0.32 : 1.0)
         .animation(.easeInOut(duration: 0.2), value: todoItem.isCompleted)
-        .onTapGesture {
-            if onTitleChanged != nil && !isEditing {
-                startEditing()
-            }
-        }
-        .onChange(of: isEditingMode) { _, newValue in
-            if newValue && onTitleChanged != nil {
-                startEditing()
-            }
-        }
-    }
-}
-
-// MARK: - 편집 기능
-private extension TodoCheckboxComponent {
-    @ViewBuilder
-    var titleSection: some View {
-        if isEditing {
-            TextField("할 일을 입력하세요", text: $editingTitle)
-                .font(.body2)
-                .foregroundColor(DS.Colors.Neutral.gray900)
-                .focused($isTextFieldFocused)
-                .onSubmit {
-                    finishEditing()
-                }
-        } else {
-            Text(todoItem.title)
-                .font(.body2)
-                .foregroundColor(DS.Colors.Neutral.gray900)
-                .lineLimit(1)
-        }
-    }
-    
-    func startEditing() {
-        editingTitle = todoItem.title
-        isEditing = true
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            isTextFieldFocused = true
-        }
-    }
-    
-    func finishEditing() {
-        let trimmedTitle = editingTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        if !trimmedTitle.isEmpty && trimmedTitle != todoItem.title {
-            onTitleChanged?(trimmedTitle)
-        }
-        
-        isEditing = false
-        isTextFieldFocused = false
     }
 }
 
@@ -204,20 +140,16 @@ private extension TodoCheckboxComponent {
         TodoCheckboxComponent(
             isCompleted: false,
             title: "기본 개인 할일",
-            onToggle: { },
-            onTitleChanged: { newTitle in
-                print("제목 변경: \(newTitle)")
-            }
+            onToggle: { print("체크박스 클릭") },
+            onMoreTapped: { print("더보기 클릭") }
         )
         
         TodoCheckboxComponent(
-            isCompleted: false,
-            title: "편집 모드 할일",
-            onToggle: { },
-            onTitleChanged: { newTitle in
-                print("제목 변경: \(newTitle)")
-            },
-            isEditingMode: true
+            isCompleted: true,
+            title: "완료된 할일",
+            category: TodoCategory(name: "연차", color: DS.Colors.TaskItem.purple),
+            onToggle: { print("체크박스 클릭") },
+            onMoreTapped: { print("더보기 클릭") }
         )
     }
     .background(Color.gray.opacity(0.1))

--- a/Projects/Shared/DesignSystem/Sources/UIComponents/TodoList/TodoCheckboxComponent.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIComponents/TodoList/TodoCheckboxComponent.swift
@@ -1,5 +1,5 @@
 //
-//  TodoCheckboxComponent.swift
+//  TodoCheckboxComponent.swift - onMoreTapped 수정
 //  Shared
 //
 //  Created by 이지훈 on 6/22/25.
@@ -24,7 +24,7 @@ public struct TodoItem: Identifiable {
     public var isCompleted: Bool
     public let category: TodoCategory?
     public let time: String?
-    public var scheduleId: String? // API의 실제 일정 ID
+    public let scheduleId: String?  // 🔥 추가: API에서 온 일정의 ID
     
     public init(id: Int, title: String, isCompleted: Bool, category: TodoCategory?, time: String?, scheduleId: String? = nil) {
         self.id = id
@@ -32,7 +32,7 @@ public struct TodoItem: Identifiable {
         self.isCompleted = isCompleted
         self.category = category
         self.time = time
-        self.scheduleId = scheduleId // scheduleId 파라미터 추가
+        self.scheduleId = scheduleId
     }
 }
 
@@ -66,7 +66,6 @@ public struct TodoCheckboxComponent: View {
         title: String,
         category: TodoCategory? = TodoCategory(name: "개인", color: DS.Colors.TaskItem.orange),
         time: String? = nil,
-        scheduleId: String? = nil, // scheduleId 파라미터 추가
         onToggle: @escaping () -> Void,
         onMoreTapped: (() -> Void)? = nil,
         onTitleChanged: ((String) -> Void)? = nil,
@@ -78,7 +77,7 @@ public struct TodoCheckboxComponent: View {
             isCompleted: isCompleted,
             category: category,
             time: time,
-            scheduleId: scheduleId // scheduleId 전달
+            scheduleId: nil
         )
         self.onToggle = onToggle
         self.onMoreTapped = onMoreTapped
@@ -130,13 +129,16 @@ public struct TodoCheckboxComponent: View {
             
             Spacer()
             
+            // 🔥 더보기 버튼 - 정확한 동작 보장
             Button(action: {
+                print("🟡 More button tapped for todo: \(todoItem.title)")
                 onMoreTapped?()
             }) {
                 DS.Images.icnThreeDots
                     .resizable()
                     .frame(width: 32, height: 32)
             }
+            .buttonStyle(PlainButtonStyle()) // 🔥 버튼 스타일 명시
         }
         .padding(.vertical, 12)
         .padding(.leading, 24)
@@ -195,4 +197,28 @@ private extension TodoCheckboxComponent {
         isEditing = false
         isTextFieldFocused = false
     }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        TodoCheckboxComponent(
+            isCompleted: false,
+            title: "기본 개인 할일",
+            onToggle: { },
+            onTitleChanged: { newTitle in
+                print("제목 변경: \(newTitle)")
+            }
+        )
+        
+        TodoCheckboxComponent(
+            isCompleted: false,
+            title: "편집 모드 할일",
+            onToggle: { },
+            onTitleChanged: { newTitle in
+                print("제목 변경: \(newTitle)")
+            },
+            isEditingMode: true
+        )
+    }
+    .background(Color.gray.opacity(0.1))
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #78 

## 📄 작업 내용
- 연차일경우 뒤로미루기 불가
- 컴포넌트 터치이벤트 제거


|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = ""> | <img src = "https://github.com/user-attachments/assets/7f7d1c87-9f7a-4b32-8063-475654ffb848" width ="250"> |


## 👀 기타 더 이야기해볼 점
빵 이미지 매핑과 할일 수정하기, 태그 추천 로직은 서버 회신후 다시 연결하겟습니다


### ✔️ CI Completed
- ✅ Lint: Completed
- ✅ Build: Completed



### ✔️ CI Completed
- ✅ Lint: Completed
- ✅ Build: Completed
