### PR TITLE
[Feat/#113] 캘린더전부뜯어고치기

### DIFF
--- a/Projects/App/Sources/Tabbar/TabBarView.swift
+++ b/Projects/App/Sources/Tabbar/TabBarView.swift
@@ -17,7 +17,7 @@ public struct TabBarView: View {
         case home = 0
         case calendar
         case profile
-
+        
         var title: String {
             switch self {
             case .home: return "홈"
@@ -25,7 +25,7 @@ public struct TabBarView: View {
             case .profile: return "내 정보"
             }
         }
-
+        
         var iconOn: Image {
             switch self {
             case .home:
@@ -36,7 +36,7 @@ public struct TabBarView: View {
                 return DS.Images.icnPersonOn
             }
         }
-
+        
         var iconOff: Image {
             switch self {
             case .home:
@@ -48,12 +48,13 @@ public struct TabBarView: View {
             }
         }
     }
-
+    
     @State private var selectedTab: Tab = .home
     @EnvironmentObject var appCoordinator: AppCoordinator
-
+    @State private var calendarTargetDate: Date?
+    
     public init() {}
-
+    
     public var body: some View {
         TabView(selection: $selectedTab) {
             // 홈 탭
@@ -63,9 +64,9 @@ public struct TabBarView: View {
                     Text(Tab.home.title)
                 }
                 .tag(Tab.home)
-
+            
             // 캘린더 탭
-            CalendarCoordinatorView()
+            CalendarCoordinatorView(initialDate: calendarTargetDate)
                 .tabItem {
                     (selectedTab == .calendar ? Tab.calendar.iconOn : Tab.calendar.iconOff)
                     Text(Tab.calendar.title)
@@ -81,8 +82,14 @@ public struct TabBarView: View {
                 .tag(Tab.profile)
         }
         .accentColor(DS.Colors.Neutral.gray900)
-        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SwitchToCalendarTab"))) { _ in
-            selectedTab = .calendar
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SwitchToCalendarTab"))) { notification in
+                    selectedTab = .calendar
+            if let userInfo = notification.userInfo,
+                           let selectedDate = userInfo["selectedDate"] as? Date {
+                            calendarTargetDate = selectedDate
+                        } else {
+                            calendarTargetDate = nil
+                        }
         }
     }
 }

--- a/Projects/Calendar/CalendarData/Sources/DTOs/UpdateScheduleStateResponseDTO.swift
+++ b/Projects/Calendar/CalendarData/Sources/DTOs/UpdateScheduleStateResponseDTO.swift
@@ -1,0 +1,15 @@
+//
+//  UpdateScheduleStateResponseDTO.swift
+//  CalendarData
+//
+//  Created by 이지훈 on 7/17/25.
+//  Copyright © 2025 com.noweekend. All rights reserved.
+//
+
+import Foundation
+
+public struct UpdateScheduleStateResponseDTO: Decodable {
+    public let result: String
+    public let data: UpdateScheduleResponseDTO?
+    public let error: APIError?
+}

--- a/Projects/Calendar/CalendarData/Sources/Repositories/CalendarRepositoryImpl.swift
+++ b/Projects/Calendar/CalendarData/Sources/Repositories/CalendarRepositoryImpl.swift
@@ -140,4 +140,23 @@ public final class CalendarRepositoryImpl: CalendarRepositoryProtocol {
         
         return response
     }
+    
+    public func updateScheduleState(id: String, isComplete: Bool) async throws -> Schedule {
+        let endpoint = "/schedule/\(id)/state?is_complete=\(isComplete)"
+        
+        let response: UpdateScheduleStateResponseDTO = try await networkService.put(
+            endpoint: endpoint,
+            parameters: nil  
+        )
+        
+        guard response.result == "SUCCESS", let data = response.data else {
+            let errorMessage = response.error?.message ?? "일정 상태 업데이트 실패"
+            print("❌ 일정 상태 업데이트 실패: \(errorMessage)")
+            throw NetworkError.serverError(errorMessage)
+        }
+        
+        let schedule = data.toDomain()
+        print("✅ 일정 상태 업데이트 성공: \(schedule.title), 완료: \(schedule.completed)")
+        return schedule
+    }
 }

--- a/Projects/Calendar/CalendarDomain/Sources/Repositories/CalendarRepositoryProtocol.swift
+++ b/Projects/Calendar/CalendarDomain/Sources/Repositories/CalendarRepositoryProtocol.swift
@@ -13,5 +13,6 @@ public protocol CalendarRepositoryProtocol {
     func createSchedule(request: CreateScheduleRequest) async throws -> Schedule
     func updateSchedule(id: String, request: UpdateScheduleRequest) async throws -> Schedule
     func deleteSchedule(id: String) async throws
-    func getRecommendedTags() async throws -> RecommendTagResponse 
+    func getRecommendedTags() async throws -> RecommendTagResponse
+    func updateScheduleState(id: String, isComplete: Bool) async throws -> Schedule
 }

--- a/Projects/Calendar/CalendarDomain/Sources/UseCase/CalendarUseCase.swift
+++ b/Projects/Calendar/CalendarDomain/Sources/UseCase/CalendarUseCase.swift
@@ -126,4 +126,8 @@ private extension CalendarUseCase {
         
         return (firstWeekStart, lastWeekEnd)
     }
+    
+    public func updateScheduleState(id: String, isComplete: Bool) async throws -> Schedule {
+        return try await calendarRepository.updateScheduleState(id: id, isComplete: isComplete)
+    }
 }

--- a/Projects/Calendar/CalendarDomain/Sources/UseCase/CalendarUseCaseProtocol.swift
+++ b/Projects/Calendar/CalendarDomain/Sources/UseCase/CalendarUseCaseProtocol.swift
@@ -33,5 +33,7 @@ public protocol CalendarUseCaseProtocol {
         alarmOption: AlarmOption
     ) async throws -> Schedule
     func deleteSchedule(id: String) async throws
-    func getRecommendedTags() async throws -> RecommendTagResponse 
+    func getRecommendedTags() async throws -> RecommendTagResponse
+    func updateScheduleState(id: String, isComplete: Bool) async throws -> Schedule
+
 }

--- a/Projects/Calendar/CalendarFeature/Sources/Coordinator/CalendarCoordinator.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Coordinator/CalendarCoordinator.swift
@@ -24,8 +24,8 @@ public final class CalendarCoordinator: ObservableObject, Coordinatorable {
     @ViewBuilder
     public func view(_ screen: Screen) -> some View {
         switch screen {
-        case .main:
-            CalendarView()
+        case .main(let initialDate):
+            CalendarView(initialDate: initialDate)
         case .taskCreate(let selectedDate):
             TaskCreateView(selectedDate: selectedDate)
         case .taskEdit(let todoId, let title, let category, let scheduleId, let selectedDate):
@@ -60,7 +60,7 @@ public final class CalendarCoordinator: ObservableObject, Coordinatorable {
 
 public enum CalendarRouter {
     public enum Screen: Hashable {
-        case main
+        case main(initialDate: Date?)
         case taskCreate(selectedDate: Date)
         case taskEdit(todoId: Int, title: String, category: String?, scheduleId: String?, selectedDate: Date)
         case dateDetail(selectedDate: Date)

--- a/Projects/Calendar/CalendarFeature/Sources/Coordinator/CalendarCoordinatorView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Coordinator/CalendarCoordinatorView.swift
@@ -11,13 +11,16 @@ import SwiftUI
 public struct CalendarCoordinatorView: View {
     @StateObject private var coordinator = CalendarCoordinator()
     
-    public init() {
-        print("📅 CalendarCoordinatorView 초기화")
+    private let initialDate: Date?
+
+    public init(initialDate: Date? = nil) {
+        self.initialDate = initialDate
+        print("📅 CalendarCoordinatorView 초기화 - initialDate: \(initialDate?.description ?? "nil")")
     }
     
     public var body: some View {
         NavigationStack(path: $coordinator.path) {
-            coordinator.view(.main)
+            coordinator.view(.main(initialDate: initialDate))
                 .navigationDestination(for: CalendarRouter.Screen.self) { screen in
                     coordinator.view(screen)
                         .environmentObject(coordinator)

--- a/Projects/Calendar/CalendarFeature/Sources/Views/Calendar/CalendarSection.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/Calendar/CalendarSection.swift
@@ -33,6 +33,7 @@ struct CalendarSection: View {
             case .week:
                 WeekCalendarView(
                     baseDate: selectedDate,
+                    selectedDate: selectedDate,  
                     onDateTap: onDateTap
                 ) { date in
                     calendarCellContent(date)

--- a/Projects/Calendar/CalendarFeature/Sources/Views/Calendar/MonthCalendarView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/Calendar/MonthCalendarView.swift
@@ -102,7 +102,8 @@ struct MonthCalendarView: View {
             }) {
                 VStack(spacing: 1) {
                     ZStack {
-                        if isToday {
+                        if isSelected {
+                            // 선택된 날짜에만 circle 표시
                             Circle()
                                 .fill(DS.Colors.Toast._100)
                                 .frame(width: 32, height: 32)
@@ -110,7 +111,10 @@ struct MonthCalendarView: View {
                         
                         Text("\(calendar.component(.day, from: date))")
                             .font(.subtitle1)
-                            .foregroundStyle(isToday ? DS.Colors.Toast._700 : DS.Colors.Text.netural)
+                            .foregroundStyle(
+                                isSelected ? DS.Colors.Toast._700 :
+                                (isToday ? DS.Colors.Toast._700 : DS.Colors.Text.netural)
+                            )
                     }
                     .frame(height: 41)
                     

--- a/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/DateDetailIntent.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/DateDetailIntent.swift
@@ -20,4 +20,5 @@ public enum DateDetailIntent {
     case hideCategorySelection
     case selectCategory(TaskCategory)
     case navigateToTaskCreate
+    case taskCompletionToggled(Int)
 }

--- a/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/DateDetailStore.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/DateDetailStore.swift
@@ -31,8 +31,11 @@ public class DateDetailStore {
             Task { await loadSchedules() }
             
         case .toggleTask(let index):
-            guard index < state.todoItems.count else { return }
-            state.todoItems[index].isCompleted.toggle()
+            // 기존의 로컬 토글을 API 연동으로 변경
+            Task { await handleTaskCompletionToggled(index) }
+            
+        case .taskCompletionToggled(let index):
+            Task { await handleTaskCompletionToggled(index) }
             
         case .showTaskEditSheet(let index):
             state.selectedTaskIndex = index
@@ -53,8 +56,7 @@ public class DateDetailStore {
         case .deleteTask:
             state.showTaskEditSheet = false
             if let index = state.selectedTaskIndex {
-                state.todoItems.remove(at: index)
-                state.selectedTaskIndex = nil
+                Task { await handleTaskDelete(index) }
             }
             
         case .showCategorySelection:
@@ -170,4 +172,60 @@ private extension DateDetailStore {
             scheduleId: schedule.id
         )
     }
+
+    @MainActor
+    func handleTaskCompletionToggled(_ index: Int) async {
+        guard index < state.todoItems.count else { return }
+        
+        let todoItem = state.todoItems[index]
+        
+        guard let scheduleId = todoItem.scheduleId else {
+            state.todoItems[index].isCompleted.toggle()
+            return
+        }
+        
+        let previousState = state.todoItems[index].isCompleted
+        state.todoItems[index].isCompleted = !previousState
+        
+        do {
+            let updatedSchedule = try await calendarUseCase?.updateScheduleState(
+                id: scheduleId,
+                isComplete: !previousState
+            )
+            
+            state.todoItems[index].isCompleted = ((updatedSchedule?.completed) != nil)
+            
+        
+            await loadSchedules()
+            
+        } catch {
+            state.todoItems[index].isCompleted = previousState
+        }
+    }
+
+    @MainActor
+      func handleTaskDelete(_ index: Int) async {
+          guard index < state.todoItems.count else { return }
+          
+          let todoItem = state.todoItems[index]
+          
+          guard let scheduleId = todoItem.scheduleId else {
+              state.todoItems.remove(at: index)
+              state.selectedTaskIndex = nil
+              return
+          }
+          
+          do {
+              let useCase = calendarUseCase ?? DIContainer.shared.resolve(CalendarUseCaseProtocol.self)
+              try await useCase.deleteSchedule(id: scheduleId)
+              
+              state.todoItems.remove(at: index)
+              state.selectedTaskIndex = nil
+              
+              await loadSchedules()
+              
+          } catch {
+              state.errorMessage = "일정 삭제에 실패했습니다: \(error.localizedDescription)"
+          }
+      }
 }

--- a/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/DateDetailView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/DateDetailView.swift
@@ -13,7 +13,6 @@ import SwiftUI
 public struct DateDetailView: View {
     @EnvironmentObject private var coordinator: CalendarCoordinator
     @State private var store: DateDetailStore
-    @Environment(\.presentationMode) private var presentationMode
     
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -71,7 +70,7 @@ private extension DateDetailView {
         CustomNavigationBar(
             type: .backWithLabel(dateFormatter.string(from: store.selectedDate)),
             onBackTapped: {
-                presentationMode.wrappedValue.dismiss()
+                coordinator.pop()
             }
         )
     }
@@ -107,7 +106,10 @@ private extension DateDetailView {
                 TodoListSection(
                     todoItems: store.state.todoItems,
                     incompleteTodoCount: store.state.incompleteTodoCount,
-                    onToggle: { index in store.send(.toggleTask(index: index)) },
+                    onToggle: { index in
+                        // 올바른 API 연동 Intent 호출
+                        store.send(.taskCompletionToggled(index))
+                    },
                     onMoreTapped: { index in store.send(.showTaskEditSheet(index: index)) }
                 )
                 .padding(.top, 24)
@@ -116,7 +118,6 @@ private extension DateDetailView {
             }
         }
     }
-    
     @ViewBuilder
     var overlayContent: some View {
         if store.state.showCategorySelection {

--- a/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/TodoListSection.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/Todo/DetailPage/TodoListSection.swift
@@ -62,7 +62,9 @@ struct TodoListSection: View {
                     ForEach(Array(todoItems.enumerated()), id: \.element.id) { index, todo in
                         TodoCheckboxComponent(
                             todoItem: todo,
-                            onToggle: { onToggle(index) },
+                            onToggle: {
+                                onToggle(index)
+                            },
                             onMoreTapped: { onMoreTapped(index) }
                         )
                         .contentShape(Rectangle())

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarModels.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarModels.swift
@@ -26,6 +26,7 @@ public enum CalendarIntent {
     case taskTitleChanged(Int, String)
     case categorySelectionToggled
     case scrollOffsetChanged(CGFloat, Bool)
+    case taskCompletionToggled(Int)
 }
 
 // MARK: - State (UI 상태)

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarModels.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarModels.swift
@@ -27,6 +27,7 @@ public enum CalendarIntent {
     case categorySelectionToggled
     case scrollOffsetChanged(CGFloat, Bool)
     case taskCompletionToggled(Int)
+    case taskMoreTapped(Int)
 }
 
 // MARK: - State (UI 상태)

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarStore.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarStore.swift
@@ -40,32 +40,34 @@ public final class CalendarStore: ObservableObject {
     @MainActor
     private func handle(_ intent: CalendarIntent) async {
         switch intent {
-        case .viewDidAppear:
-            await handleViewDidAppear()
-        case .toggleChanged(let toggle):
-            await handleToggleChanged(toggle)
-        case .dateSelected(let date):
-            await handleDateSelected(date)
-        case .dateDetailRequested(let date):
-            handleDateDetailRequested(date)
-        case .categorySelected(let category):
-            handleCategorySelected(category)
-        case .directInputTapped:
-            handleDirectInputTapped()
-        case .taskEditRequested(let index):
-            handleTaskEditRequested(index)
-        case .taskTomorrowRequested(let index):
-            await handleTaskTomorrowRequested(index)
-        case .taskDeleteRequested(let index):
-            await handleTaskDeleteRequested(index)
-        case .taskTitleChanged(let index, let newTitle):
-            await handleTaskTitleChanged(index: index, newTitle: newTitle)
-        case .categorySelectionToggled:
-            handleCategorySelectionToggled()
-        case .scrollOffsetChanged(let offset, let isScrolling):
-            handleScrollOffsetChanged(offset: offset, isScrolling: isScrolling)
-        }
-    }
+               case .viewDidAppear:
+                   await handleViewDidAppear()
+               case .toggleChanged(let toggle):
+                   await handleToggleChanged(toggle)
+               case .dateSelected(let date):
+                   await handleDateSelected(date)
+               case .dateDetailRequested(let date):
+                   handleDateDetailRequested(date)
+               case .categorySelected(let category):
+                   handleCategorySelected(category)
+               case .directInputTapped:
+                   handleDirectInputTapped()
+               case .taskEditRequested(let index):
+                   handleTaskEditRequested(index)
+               case .taskTomorrowRequested(let index):
+                   await handleTaskTomorrowRequested(index)
+               case .taskDeleteRequested(let index):
+                   await handleTaskDeleteRequested(index)
+               case .taskTitleChanged(let index, let newTitle):
+                   await handleTaskTitleChanged(index: index, newTitle: newTitle)
+               case .categorySelectionToggled:
+                   handleCategorySelectionToggled()
+               case .scrollOffsetChanged(let offset, let isScrolling):
+                   handleScrollOffsetChanged(offset: offset, isScrolling: isScrolling)
+               case .taskCompletionToggled(let index):
+                   await handleTaskCompletionToggled(index)
+               }
+           }
 }
 
 // MARK: - Intent Handlers
@@ -467,4 +469,34 @@ extension CalendarStore {
             return DS.Images.imgToastDefault
         }
     }
+    @MainActor
+        func handleTaskCompletionToggled(_ index: Int) async {
+            guard index < state.todoItems.count else { return }
+            
+            let todoItem = state.todoItems[index]
+            
+            guard let scheduleId = todoItem.scheduleId else {
+                state.todoItems[index].isCompleted.toggle()
+                return
+            }
+            
+            let previousState = state.todoItems[index].isCompleted
+            state.todoItems[index].isCompleted = !previousState
+            
+            do {
+                let updatedSchedule = try await calendarUseCase.updateScheduleState(
+                    id: scheduleId,
+                    isComplete: !previousState
+                )
+                
+                state.todoItems[index].isCompleted = updatedSchedule.completed
+                
+                let message = updatedSchedule.completed ? "할일을 완료했습니다" : "할일을 미완료로 변경했습니다"
+                effectSubject.send(.showSuccess(message))
+                
+            } catch {
+                state.todoItems[index].isCompleted = previousState
+                effectSubject.send(.showError("할일 상태 변경에 실패했습니다: \(error.localizedDescription)"))
+            }
+        }
 }

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarStore.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarStore.swift
@@ -40,34 +40,36 @@ public final class CalendarStore: ObservableObject {
     @MainActor
     private func handle(_ intent: CalendarIntent) async {
         switch intent {
-               case .viewDidAppear:
-                   await handleViewDidAppear()
-               case .toggleChanged(let toggle):
-                   await handleToggleChanged(toggle)
-               case .dateSelected(let date):
-                   await handleDateSelected(date)
-               case .dateDetailRequested(let date):
-                   handleDateDetailRequested(date)
-               case .categorySelected(let category):
-                   handleCategorySelected(category)
-               case .directInputTapped:
-                   handleDirectInputTapped()
-               case .taskEditRequested(let index):
-                   handleTaskEditRequested(index)
-               case .taskTomorrowRequested(let index):
-                   await handleTaskTomorrowRequested(index)
-               case .taskDeleteRequested(let index):
-                   await handleTaskDeleteRequested(index)
-               case .taskTitleChanged(let index, let newTitle):
-                   await handleTaskTitleChanged(index: index, newTitle: newTitle)
-               case .categorySelectionToggled:
-                   handleCategorySelectionToggled()
-               case .scrollOffsetChanged(let offset, let isScrolling):
-                   handleScrollOffsetChanged(offset: offset, isScrolling: isScrolling)
-               case .taskCompletionToggled(let index):
-                   await handleTaskCompletionToggled(index)
-               }
-           }
+        case .viewDidAppear:
+            await handleViewDidAppear()
+        case .toggleChanged(let toggle):
+            await handleToggleChanged(toggle)
+        case .dateSelected(let date):
+            await handleDateSelected(date)
+        case .dateDetailRequested(let date):
+            handleDateDetailRequested(date)
+        case .categorySelected(let category):
+            handleCategorySelected(category)
+        case .directInputTapped:
+            handleDirectInputTapped()
+        case .taskEditRequested(let index):
+            handleTaskEditRequested(index)
+        case .taskTomorrowRequested(let index):
+            await handleTaskTomorrowRequested(index)
+        case .taskDeleteRequested(let index):
+            await handleTaskDeleteRequested(index)
+        case .taskTitleChanged(let index, let newTitle):
+            await handleTaskTitleChanged(index: index, newTitle: newTitle)
+        case .categorySelectionToggled:
+            handleCategorySelectionToggled()
+        case .scrollOffsetChanged(let offset, let isScrolling):
+            handleScrollOffsetChanged(offset: offset, isScrolling: isScrolling)
+        case .taskCompletionToggled(let index):
+            await handleTaskCompletionToggled(index)
+        case .taskMoreTapped(let index):
+            handleTaskMoreTapped(index)
+        }
+    }
 }
 
 // MARK: - Intent Handlers
@@ -117,6 +119,14 @@ private extension CalendarStore {
     func handleDirectInputTapped() {
         state.showCategorySelection = false
         effectSubject.send(.navigateToTaskCreate(state.selectedDate))
+    }
+    
+    @MainActor
+    func handleTaskMoreTapped(_ index: Int) {
+        guard index < state.todoItems.count else { return }
+        
+        state.selectedTaskIndex = index
+        state.showTaskEditSheet = true
     }
     
     @MainActor

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
@@ -112,6 +112,7 @@ private extension CalendarView {
             )
             
             contentSection
+            Spacer()
         }
         .background(.white)
     }

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
@@ -21,7 +21,10 @@ public struct CalendarView: View {
     @State private var showTaskEditSheet = false
     @State private var datePickerSelectedDate = Date()
     
-    public init() {}
+    private let initialDate: Date?
+    public init(initialDate: Date? = nil) {
+        self.initialDate = initialDate
+    }
     
     public var body: some View {
         ZStack {
@@ -74,10 +77,12 @@ public struct CalendarView: View {
                 }
             }
         }
-        .onChange(of: store.state.showTaskEditSheet) { _, newValue in
-            if newValue != showTaskEditSheet {
-                showTaskEditSheet = newValue
+        .onAppear {
+            // 수정된 부분: 초기 날짜가 있으면 해당 날짜로 설정
+            if let initialDate = initialDate {
+                store.send(.dateSelected(initialDate))
             }
+            store.send(.viewDidAppear)
         }
         .onReceive(store.effect) { effect in
             handleEffect(effect)

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
@@ -135,15 +135,12 @@ private extension CalendarView {
                             store.send(.taskCompletionToggled(index))
                         },
                         onMoreTapped: { index in
-                            store.send(.taskEditRequested(index))
+                            store.send(.taskMoreTapped(index))
                         }
                     )
                     .padding(.top, 24)
                     
                     Spacer(minLength: 100)
-                }
-                .scrollTrackingModifier { offset, isScrolling in
-                    store.send(.scrollOffsetChanged(offset, isScrolling))
                 }
                 .background(.white)
             }

--- a/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
+++ b/Projects/Calendar/CalendarFeature/Sources/Views/View/CalendarView.swift
@@ -127,63 +127,26 @@ private extension CalendarView {
                 }
                 .background(.white)
             } else {
-                TodoScrollSection(
-                    todoItems: Binding(
-                        get: { store.state.todoItems },
-                        set: { newValue in
-                            Task { @MainActor in
-                                store.updateState { $0.todoItems = newValue }
-                            }
+                ScrollView {
+                    TodoListSection(
+                        todoItems: store.state.todoItems,
+                        incompleteTodoCount: store.state.todoItems.filter { !$0.isCompleted }.count,
+                        onToggle: { index in
+                            store.send(.taskCompletionToggled(index))
+                        },
+                        onMoreTapped: { index in
+                            store.send(.taskEditRequested(index))
                         }
-                    ),
-                    selectedTaskIndex: Binding(
-                        get: { store.state.selectedTaskIndex },
-                        set: { newValue in
-                            Task { @MainActor in
-                                store.updateState { state in
-                                    state.selectedTaskIndex = newValue
-                                    if newValue != nil {
-                                        state.showTaskEditSheet = true
-                                    }
-                                }
-                            }
-                        }
-                    ),
-                    showTaskEditSheet: Binding(
-                        get: { showTaskEditSheet },
-                        set: { newValue in
-                            showTaskEditSheet = newValue
-                        }
-                    ),
-                    scrollOffset: Binding(
-                        get: { store.state.scrollOffset },
-                        set: { newValue in
-                            store.send(.scrollOffsetChanged(newValue, store.state.isScrolling))
-                        }
-                    ),
-                    isScrolling: Binding(
-                        get: { store.state.isScrolling },
-                        set: { newValue in
-                            store.send(.scrollOffsetChanged(store.state.scrollOffset, newValue))
-                        }
-                    ),
-                    editingTaskIndex: Binding(
-                        get: { store.state.editingTaskIndex },
-                        set: { newValue in
-                            Task { @MainActor in
-                                store.updateState { $0.editingTaskIndex = newValue }
-                            }
-                        }
-                    ),
-                    onTitleChanged: { index, newTitle in
-                        store.send(.taskTitleChanged(index, newTitle))
-                    }
-                )
+                    )
+                    .padding(.top, 24)
+                    
+                    Spacer(minLength: 100)
+                }
+                .scrollTrackingModifier { offset, isScrolling in
+                    store.send(.scrollOffsetChanged(offset, isScrolling))
+                }
                 .background(.white)
             }
-        } else {
-            Spacer()
-                .background(.white)
         }
     }
     
@@ -275,5 +238,22 @@ private extension CalendarView {
         case .showSuccess(let message):
             print("✅ Success: \(message)")
         }
+    }
+}
+
+extension ScrollView {
+    func scrollTrackingModifier(onScrollChanged: @escaping (CGFloat, Bool) -> Void) -> some View {
+        self.background(
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: ScrollOffsetPreferenceKey.self,
+                    value: geometry.frame(in: .named("scroll")).minY
+                )
+            }
+        )
+        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+            onScrollChanged(value, abs(value) > 1)
+        }
+        .coordinateSpace(name: "scroll")
     }
 }

--- a/Projects/Home/HomeFeature/Sources/Home/HomeView.swift
+++ b/Projects/Home/HomeFeature/Sources/Home/HomeView.swift
@@ -222,7 +222,7 @@ public struct HomeView: View {
                 inputText = ""
                 resetSelectedItems()
                 
-                switchToCalendarTab()
+                switchToCalendarTab(with: targetDate)
             }
             
         } catch {
@@ -334,10 +334,17 @@ public struct HomeView: View {
         store.send(.refreshData)
     }
     
-    private func switchToCalendarTab() {
+    private func switchToCalendarTab(with date: Date? = nil) {
+        var userInfo: [String: Any] = [:]
+        
+        if let date = date {
+            userInfo["selectedDate"] = date
+        }
+        
         NotificationCenter.default.post(
             name: NSNotification.Name("SwitchToCalendarTab"),
-            object: nil
+            object: nil,
+            userInfo: userInfo
         )
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/UIComponents/Calendar/calendarComponent.swift
+++ b/Projects/Shared/DesignSystem/Sources/UIComponents/Calendar/calendarComponent.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 public struct WeekCalendarView<Content: View>: View {
     let baseDate: Date
+    let selectedDate: Date
     let onDateTap: ((Date) -> Void)?
     let cellContent: (Date) -> Content
     
@@ -33,10 +34,12 @@ public struct WeekCalendarView<Content: View>: View {
     
     public init(
         baseDate: Date = Date(),
+        selectedDate: Date = Date(),
         onDateTap: ((Date) -> Void)? = nil,
         @ViewBuilder cellContent: @escaping (Date) -> Content
     ) {
         self.baseDate = baseDate
+        self.selectedDate = selectedDate
         self.onDateTap = onDateTap
         self.cellContent = cellContent
     }
@@ -69,7 +72,10 @@ public struct WeekCalendarView<Content: View>: View {
                 }) {
                     VStack(spacing: 1) {
                         ZStack {
-                            if calendar.isDateInToday(date) {
+                            let isToday = calendar.isDateInToday(date)
+                            let isSelected = calendar.isDate(date, inSameDayAs: selectedDate)
+                            
+                            if isSelected {
                                 Circle()
                                     .fill(DS.Colors.Toast._100)
                                     .frame(width: 32, height: 32)
@@ -77,7 +83,10 @@ public struct WeekCalendarView<Content: View>: View {
                             
                             Text("\(calendar.component(.day, from: date))")
                                 .font(.subtitle2)
-                                .foregroundColor(calendar.isDateInToday(date) ? DS.Colors.Toast._700 : DS.Colors.Neutral.gray900)
+                                .foregroundColor(
+                                    isSelected ? DS.Colors.Toast._700 :
+                                    (isToday ? DS.Colors.Toast._700 : DS.Colors.Neutral.gray900)
+                                )
                         }
                         .frame(height: 41)
                         


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #113 


## 📄 작업 내용
- 캘린더 Circle 선택된 날짜로 수정
- 할일 완료시 빵 구워지게 API 매핑
- 할일 추가로 홈화며네서 추가하면 해당하는 날짜로 이동
- 좀더 자연스러운 애니메이션

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/2e1fd2a1-4dc6-442b-87a8-21a7b1a8f2e4
" width ="250"> | <img src = "https://github.com/user-attachments/assets/dadc1d60-490e-48da-bf4e-0b3b260548d1
" width ="250"> |


## 👀 기타 더 이야기해볼 점
화이탕후루



### ✔️ CI Completed
- ✅ Lint: Completed
- ✅ Build: Completed
