### PR TITLE
[Feat/#131] CI코드수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI (Lint + Test)
 on:
   pull_request:
     branches: [main, develop, release/**]
+  push:
+    branches: [feat/**]  # 테스트용 추가
 
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1
@@ -122,6 +124,7 @@ jobs:
         run: bundle exec fastlane build
 
       - name: Update PR Description
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, develop, release/**]
   push:
-    branches: [feat/**]  # 테스트용 추가
+    branches: [feat/**]
 
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1
@@ -46,14 +46,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tuist-
 
-      - name: Cache Homebrew packages
-        uses: actions/cache@v3
-        with:
-          path: /opt/homebrew/Cellar
-          key: ${{ runner.os }}-brew-swiftlint-mise
-          restore-keys: |
-            ${{ runner.os }}-brew-
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -64,21 +56,35 @@ jobs:
           bundle config set --local path 'vendor/bundle'
           bundle config set --local jobs 4
           
+          # Homebrew 설치를 백그라운드에서 실행
           (brew install swiftlint mise) &
           BREW_PID=$!
           
+          # Bundle install 동시 실행
           bundle install --jobs 4 --retry 3
           
+          # Brew 설치 완료 대기
           wait $BREW_PID
 
+      - name: Verify mise installation
+        run: |
+          which mise || echo "mise not found in PATH"
+          echo "PATH: $PATH"
+          ls -la /opt/homebrew/bin/ | grep mise || echo "mise not in homebrew bin"
+
       - name: Enable idiomatic version files for ruby
-        run: mise settings add idiomatic_version_file_enable_tools ruby
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          mise settings add idiomatic_version_file_enable_tools ruby
 
       - name: Install tools with mise
-        run: mise install
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          mise install
 
       - name: Check tuist version
         run: |
+          export PATH="/opt/homebrew/bin:$PATH"
           eval "$(mise activate bash)"
           tuist version
 
@@ -97,6 +103,7 @@ jobs:
 
       - name: Tuist tasks (install + generate)
         run: |
+          export PATH="/opt/homebrew/bin:$PATH"
           eval "$(mise activate bash)"
           tuist install
           tuist generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,27 +4,70 @@ on:
   pull_request:
     branches: [main, develop, release/**]
 
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   ci:
     runs-on: macos-latest
+    timeout-minutes: 30
     permissions:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
+
+      - name: Cache Ruby gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Cache mise tools
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/mise
+          key: ${{ runner.os }}-mise-${{ hashFiles('.mise.toml', 'Tuist/Dependencies.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-mise-
+
+      - name: Cache Tuist dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            Tuist/Dependencies
+            ~/.tuist/Cache
+          key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Dependencies.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-tuist-
+
+      - name: Cache Homebrew packages
+        uses: actions/cache@v3
+        with:
+          path: /opt/homebrew/Cellar
+          key: ${{ runner.os }}-brew-swiftlint-mise
+          restore-keys: |
+            ${{ runner.os }}-brew-
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
 
-      - name: Install dependencies
-        run: bundle install
-
-      - name: Install SwiftLint
-        run: brew install swiftlint
-
-      - name: Install mise
-        run: brew install mise
+      - name: Install dependencies in parallel
+        run: |
+          bundle config set --local path 'vendor/bundle'
+          bundle config set --local jobs 4
+          
+          (brew install swiftlint mise) &
+          BREW_PID=$!
+          
+          bundle install --jobs 4 --retry 3
+          
+          wait $BREW_PID
 
       - name: Enable idiomatic version files for ruby
         run: mise settings add idiomatic_version_file_enable_tools ruby
@@ -39,7 +82,7 @@ jobs:
 
       - name: Create Config.swift for Network
         run: |
-          cat <<EOF > Projects/Core/NWNetwork/Sources/Config.swift
+          cat <<CONFIGEOF > Projects/Core/NWNetwork/Sources/Config.swift
           import Foundation
 
           public enum Config {
@@ -48,7 +91,7 @@ jobs:
               public static let googleServerClientID = "${{ secrets.GOOGLE_SERVICE_CLIENT_ID }}"
               public static let tempAccessToken = "${{ secrets.TEMP_ACCESS_TOKEN }}"
           }
-          EOF
+          CONFIGEOF
 
       - name: Tuist tasks (install + generate)
         run: |
@@ -58,6 +101,7 @@ jobs:
 
       - name: Create & Unlock Keychain
         run: |
+          security delete-keychain ci.keychain 2>/dev/null || true
           security create-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
           security default-keychain -s ci.keychain
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
@@ -100,4 +144,4 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
               body: updated
-            }); 
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,157 +1,146 @@
 name: CI (Lint + Test)
 
 on:
-  pull_request:
-    branches: [main, develop, release/**]
-  push:
-    branches: [feat/**]
+ pull_request:
+   branches: [main, develop, release/**]
 
 env:
-  HOMEBREW_NO_AUTO_UPDATE: 1
-  BUNDLE_JOBS: 4
-  BUNDLE_RETRY: 3
+ HOMEBREW_NO_AUTO_UPDATE: 1
+ BUNDLE_JOBS: 4
+ BUNDLE_RETRY: 3
 
 jobs:
-  ci:
-    runs-on: macos-latest
-    timeout-minutes: 30
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v3
+ ci:
+   runs-on: macos-latest
+   timeout-minutes: 30
+   permissions:
+     pull-requests: write
+   steps:
+     - uses: actions/checkout@v3
 
-      - name: Cache Ruby gems
-        uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+     - name: Cache Ruby gems
+       uses: actions/cache@v3
+       with:
+         path: vendor/bundle
+         key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+         restore-keys: |
+           ${{ runner.os }}-gems-
 
-      - name: Cache mise tools
-        uses: actions/cache@v3
-        with:
-          path: ~/.local/share/mise
-          key: ${{ runner.os }}-mise-${{ hashFiles('.mise.toml', 'Tuist/Dependencies.swift') }}
-          restore-keys: |
-            ${{ runner.os }}-mise-
+     - name: Cache mise tools
+       uses: actions/cache@v3
+       with:
+         path: ~/.local/share/mise
+         key: ${{ runner.os }}-mise-${{ hashFiles('.mise.toml', 'Tuist/Dependencies.swift') }}
+         restore-keys: |
+           ${{ runner.os }}-mise-
 
-      - name: Cache Tuist dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            Tuist/Dependencies
-            ~/.tuist/Cache
-          key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Dependencies.swift') }}
-          restore-keys: |
-            ${{ runner.os }}-tuist-
+     - name: Cache Tuist dependencies
+       uses: actions/cache@v3
+       with:
+         path: |
+           Tuist/Dependencies
+           ~/.tuist/Cache
+         key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Dependencies.swift') }}
+         restore-keys: |
+           ${{ runner.os }}-tuist-
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1'
+     - name: Set up Ruby
+       uses: ruby/setup-ruby@v1
+       with:
+         ruby-version: '3.1'
 
-      - name: Install dependencies in parallel
-        run: |
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local jobs 4
-          
-          # Homebrew 설치를 백그라운드에서 실행
-          (brew install swiftlint mise) &
-          BREW_PID=$!
-          
-          # Bundle install 동시 실행
-          bundle install --jobs 4 --retry 3
-          
-          # Brew 설치 완료 대기
-          wait $BREW_PID
+     - name: Install dependencies in parallel
+       run: |
+         bundle config set --local path 'vendor/bundle'
+         bundle config set --local jobs 4
+         
+         (brew install swiftlint mise) &
+         BREW_PID=$!
+         
+         bundle install --jobs 4 --retry 3
+         
+         wait $BREW_PID
 
-      - name: Verify mise installation
-        run: |
-          which mise || echo "mise not found in PATH"
-          echo "PATH: $PATH"
-          ls -la /opt/homebrew/bin/ | grep mise || echo "mise not in homebrew bin"
+     - name: Enable idiomatic version files for ruby
+       run: |
+         export PATH="/opt/homebrew/bin:$PATH"
+         mise settings add idiomatic_version_file_enable_tools ruby
 
-      - name: Enable idiomatic version files for ruby
-        run: |
-          export PATH="/opt/homebrew/bin:$PATH"
-          mise settings add idiomatic_version_file_enable_tools ruby
+     - name: Install tools with mise
+       run: |
+         export PATH="/opt/homebrew/bin:$PATH"
+         mise install
 
-      - name: Install tools with mise
-        run: |
-          export PATH="/opt/homebrew/bin:$PATH"
-          mise install
+     - name: Check tuist version
+       run: |
+         export PATH="/opt/homebrew/bin:$PATH"
+         eval "$(mise activate bash)"
+         tuist version
 
-      - name: Check tuist version
-        run: |
-          export PATH="/opt/homebrew/bin:$PATH"
-          eval "$(mise activate bash)"
-          tuist version
+     - name: Create Config.swift for Network
+       run: |
+         cat <<CONFIGEOF > Projects/Core/NWNetwork/Sources/Config.swift
+         import Foundation
 
-      - name: Create Config.swift for Network
-        run: |
-          cat <<CONFIGEOF > Projects/Core/NWNetwork/Sources/Config.swift
-          import Foundation
+         public enum Config {
+             public static let baseURL = "${{ secrets.BASE_URL }}"
+             public static let googleClientID = "${{ secrets.GOOGLE_CLIENT_KEY }}"
+             public static let googleServerClientID = "${{ secrets.GOOGLE_SERVICE_CLIENT_ID }}"
+             public static let tempAccessToken = "${{ secrets.TEMP_ACCESS_TOKEN }}"
+         }
+         CONFIGEOF
 
-          public enum Config {
-              public static let baseURL = "${{ secrets.BASE_URL }}"
-              public static let googleClientID = "${{ secrets.GOOGLE_CLIENT_KEY }}"
-              public static let googleServerClientID = "${{ secrets.GOOGLE_SERVICE_CLIENT_ID }}"
-              public static let tempAccessToken = "${{ secrets.TEMP_ACCESS_TOKEN }}"
-          }
-          CONFIGEOF
+     - name: Tuist tasks (install + generate)
+       run: |
+         export PATH="/opt/homebrew/bin:$PATH"
+         eval "$(mise activate bash)"
+         tuist install
+         tuist generate
 
-      - name: Tuist tasks (install + generate)
-        run: |
-          export PATH="/opt/homebrew/bin:$PATH"
-          eval "$(mise activate bash)"
-          tuist install
-          tuist generate
+     - name: Create & Unlock Keychain
+       run: |
+         security delete-keychain ci.keychain 2>/dev/null || true
+         security create-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
+         security default-keychain -s ci.keychain
+         security unlock-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
+         security set-keychain-settings -lut 21600 ci.keychain
+       env:
+         KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+         
+     - name: Install certificates & profiles
+       env:
+         MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+         MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+         KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+       run: |
+         bundle exec fastlane match development --readonly --keychain-name "ci.keychain" --keychain-password "$KEYCHAIN_PASSWORD"
+         bundle exec fastlane match appstore --readonly --keychain-name "ci.keychain" --keychain-password "$KEYCHAIN_PASSWORD"
 
-      - name: Create & Unlock Keychain
-        run: |
-          security delete-keychain ci.keychain 2>/dev/null || true
-          security create-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
-          security default-keychain -s ci.keychain
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
-          security set-keychain-settings -lut 21600 ci.keychain
-        env:
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          
-      - name: Install certificates & profiles
-        env:
-          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          bundle exec fastlane match development --readonly --keychain-name "ci.keychain" --keychain-password "$KEYCHAIN_PASSWORD"
-          bundle exec fastlane match appstore --readonly --keychain-name "ci.keychain" --keychain-password "$KEYCHAIN_PASSWORD"
+     - name: Build
+       run: bundle exec fastlane build
 
-      - name: Build
-        run: bundle exec fastlane build
+     - name: Update PR Description
+       if: github.event_name == 'pull_request'
+       uses: actions/github-script@v7
+       with:
+         github-token: ${{ secrets.GITHUB_TOKEN }}
+         script: |
+           const pr = await github.rest.pulls.get({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             pull_number: context.issue.number
+           });
 
-      - name: Update PR Description
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
+           const newStatus = `
+           ### ✔️ CI Completed
+           - ✅ Build: Completed
+           `;
 
-            const newStatus = `
-            ### ✔️ CI Completed
-            - ✅ Build: Completed
-            `;
+           const updated = (pr.data.body || "") + "\n\n" + newStatus;
 
-            const updated = (pr.data.body || "") + "\n\n" + newStatus;
-
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              body: updated
-            });
+           await github.rest.pulls.update({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             pull_number: context.issue.number,
+             body: updated
+           });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,28 +19,66 @@ on:
       new_build_number:
         required: false
 
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  BUNDLE_JOBS: 4
+  BUNDLE_RETRY: 3
+
 jobs:
   deploy:
     runs-on: macos-latest
+    timeout-minutes: 45
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     permissions:
-      contents: write  # Git tag 푸시용
+      contents: write
 
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
+      - name: Cache Ruby gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Cache mise tools
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/share/mise
+          key: ${{ runner.os }}-mise-${{ hashFiles('.mise.toml', 'Tuist/Dependencies.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-mise-
+
+      - name: Cache Tuist dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            Tuist/Dependencies
+            ~/.tuist/Cache
+          key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Dependencies.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-tuist-
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
 
-      - name: Install dependencies
-        run: bundle install
-
-      - name: Install mise
-        run: brew install mise
+      - name: Install dependencies in parallel
+        run: |
+          bundle config set --local path 'vendor/bundle'
+          bundle config set --local jobs 4
+          
+          (brew install mise) &
+          BREW_PID=$!
+          
+          bundle install --jobs 4 --retry 3
+          
+          wait $BREW_PID
 
       - name: Enable idiomatic version files for ruby
         run: mise settings add idiomatic_version_file_enable_tools ruby
@@ -50,7 +88,7 @@ jobs:
 
       - name: Create Config.swift for Network
         run: |
-          cat <<EOF > Projects/Core/NWNetwork/Sources/Config.swift
+          cat <<CONFIGEOF > Projects/Core/NWNetwork/Sources/Config.swift
           import Foundation
 
           public enum Config {
@@ -59,7 +97,7 @@ jobs:
               public static let googleServerClientID = "${{ secrets.GOOGLE_SERVICE_CLIENT_ID }}"
               public static let tempAccessToken = "${{ secrets.TEMP_ACCESS_TOKEN }}"
           }
-          EOF
+          CONFIGEOF
 
       - name: Tuist tasks (install + generate)
         run: |
@@ -69,6 +107,7 @@ jobs:
 
       - name: Create & Unlock Keychain
         run: |
+          security delete-keychain ci.keychain 2>/dev/null || true
           security create-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
           security default-keychain -s ci.keychain
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" ci.keychain
@@ -113,4 +152,4 @@ jobs:
         run: |
           bundle exec fastlane ${{ github.event.inputs.lane }} \
             new_version_number:"${{ github.event.inputs.new_version_number }}" \
-            new_build_number:"${{ github.event.inputs.new_build_number }}" 
+            new_build_number:"${{ github.event.inputs.new_build_number }}"


### PR DESCRIPTION
## 🔗 연결된 이슈
- Closed: #131 


## 📄 작업 내용
- CI 의 속도를좀 끌어올려보았습니다.

변경전
<img width="276" height="54" alt="스크린샷 2025-07-29 오후 2 31 28" src="https://github.com/user-attachments/assets/cd6cafc9-dbba-4afc-a7bb-426317def931" />

<br>

변경후
<img width="257" height="56" alt="스크린샷 2025-07-29 오후 2 31 23" src="https://github.com/user-attachments/assets/453e07c7-a1b6-49a5-afe2-9cd61eb6b55b" />


## 💻 주요 코드 설명
# CI  최적화

### 기존 CI

기존 `ci.yml` 파일은 **캐시 없이 매번 모든 의존성을 새로 설치**하는 구조였습니다

```yaml
name: CI (Lint + Test)
on:
  pull_request:
    branches: [main, develop, release/**]

jobs:
  ci:
    runs-on: macos-latest
    permissions:
      pull-requests: write
    steps:
      - uses: actions/checkout@v3

      # ❌ 캐시 없음 - 매번 새로 설치
      - name: Set up Ruby
        uses: ruby/setup-ruby@v1
        with:
          ruby-version: '3.1'

      # ❌ 순차 실행 - 시간 낭비
      - name: Install dependencies
        run: bundle install
      - name: Install SwiftLint
        run: brew install swiftlint
      - name: Install mise
        run: brew install mise

      - name: Enable idiomatic version files for ruby
        run: mise settings add idiomatic_version_file_enable_tools ruby

```

### 주요 병목점

### 1. **캐시 부재**: 매번 동일한 의존성을 새로 다운로드

- Ruby gems 200+ 패키지 매번 설치 (2-3분)
- Homebrew 패키지 매번 설치 (1-2분)
- Tuist 의존성 매번 resolve (1-2분)

### 2. **순차 실행**: 병렬 가능한 작업을 순서대로 실행

- `bundle install` → `brew install` → `mise install` 순차 대기
- 총 설치 시간이 모두 누적됨

### 3. **환경 최적화 부재**: 불필요한 작업들 실행

- Homebrew 자동 업데이트로 시간 낭비
- Bundle 병렬 설정 없음

---

### TO-BE

수정한 `ci.yml`

```yaml
name: CI (Lint + Test)
on:
  pull_request:
    branches: [main, develop, release/**]
  push:
    branches: [feat/**]  # ✅ 테스트용 트리거 추가 (사실 큰 관계는 없습니다 나중에 테스트하기 편한용)

# ✅ 환경 최적화 추가
env:
  HOMEBREW_NO_AUTO_UPDATE: 1  # Homebrew 자동 업데이트 비활성화
  BUNDLE_JOBS: 4               # Bundle 병렬 작업
  BUNDLE_RETRY: 3              # 실패 시 재시도

jobs:
  ci:
    runs-on: macos-latest
    timeout-minutes: 30        # ✅ 빠른 실패 - 30분 초과 시 종료 (근데 이럴일이 있을까..ㅋㅋ)
    permissions:
      pull-requests: write
    steps:
      - uses: actions/checkout@v3

      # ✅ 스마트 캐싱 시스템 추가
      - name: Cache Ruby gems
        uses: actions/cache@v3
        with:
          path: vendor/bundle
          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
          restore-keys: |
            ${{ runner.os }}-gems-

      - name: Cache mise tools
        uses: actions/cache@v3
        with:
          path: ~/.local/share/mise
          key: ${{ runner.os }}-mise-${{ hashFiles('.mise.toml', 'Tuist/Dependencies.swift') }}

      - name: Cache Tuist dependencies
        uses: actions/cache@v3
        with:
          path: |
            Tuist/Dependencies
            ~/.tuist/Cache
          key: ${{ runner.os }}-tuist-${{ hashFiles('Tuist/Dependencies.swift') }}

      # ✅ 병렬 처리 최적화
      - name: Install dependencies in parallel
        run: |
          bundle config set --local path 'vendor/bundle'
          bundle config set --local jobs 4

          # 백그라운드에서 brew 설치 시작
          (brew install swiftlint mise) &
          BREW_PID=$!

          # 동시에 bundle install 실행
          bundle install --jobs 4 --retry 3

          # brew 완료까지 대기
          wait $BREW_PID

      # ✅ PATH 문제 해결
      - name: Enable idiomatic version files for ruby
        run: |
          export PATH="/opt/homebrew/bin:$PATH"
          mise settings add idiomatic_version_file_enable_tools ruby

```

### 핵심 개선사항

### 1. 캐시 도입으로 기존 다운받은 의존성들 다시 다운 X

- `vendor/bundle`: Ruby gems 캐시
- `~/.local/share/mise`: mise tools 캐시
- `Tuist/Dependencies`: Tuist SPM 의존성 캐시

### 2. **병렬 처리**

```yaml
# 기존: 순차 실행 (4-5분)
bundle install     # 2분 대기
brew install       # 1분 대기
mise install       # 1분 대기

# 개선: 병렬 실행 (2분)
(brew install swiftlint mise) &  # 백그라운드
bundle install --jobs 4          # 동시 실행
wait                             # 완료 대기

```

### 3. timeout 사용

- `timeout-minutes: 30`: 무한 대기 방지

### 4. **환경 최적화**: 불필요한 작업 제거

- `HOMEBREW_NO_AUTO_UPDATE: 1`: 자동 업데이트 비활성화
- `BUNDLE_JOBS: 4`: Bundle 병렬 설치 활성화

## 👀 기타 더 이야기해볼 점
기존 코드에서 Test코드를 사용해서 해당 테스트가 우선으로 실행되는 방식으로 도전해보려 햇는데 이 방식은 테스트 커버리지가 올라와야 의미가 있을것 같아서 보류했습니다. 그때까지 킵고잉~


### ✔️ CI Completed
- ✅ Build: Completed



### ✔️ CI Completed
- ✅ Build: Completed
